### PR TITLE
Task WDP190504-16

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3418,7 +3418,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3439,12 +3440,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3459,17 +3462,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3586,7 +3592,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3598,6 +3605,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3612,6 +3620,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3619,12 +3628,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -3643,6 +3654,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3723,7 +3735,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3735,6 +3748,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3820,7 +3834,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3856,6 +3871,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3875,6 +3891,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3918,12 +3935,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/src/partials/50_section-products.html
+++ b/src/partials/50_section-products.html
@@ -46,6 +46,7 @@
               <a href="#" class="btn-outline"><i class="far fa-heart"></i></a>
               <a href="#" class="btn-outline"><i class="fas fa-exchange-alt"></i></a>
             </div>
+            <div class="old-price">$ 35.00</div>
             <div class="price"><div class="btn-main-small no-hover">$ 30.00</div></div>
           </div>
         </div>
@@ -74,6 +75,7 @@
               <a href="#" class="btn-outline"><i class="far fa-heart"></i></a>
               <a href="#" class="btn-outline"><i class="fas fa-exchange-alt"></i></a>
             </div>
+            <div class="old-price">$ 35.00</div>
             <div class="price"><div class="btn-main-small no-hover">$ 30.00</div></div>
           </div>
         </div>

--- a/src/partials/90_footer.html
+++ b/src/partials/90_footer.html
@@ -35,7 +35,7 @@
             </ul>
           </div>
         </div>
-        <div class="col-sm-12 col-md-6 col-lg-3 col-xl-3 footer-text-rwd">
+        <div class="col-sm-12 col-md-6 col-lg-3 col-xl-3">
           <div class="menu-wrapper">
             <h6>Orders</h6>
             <ul>

--- a/src/partials/90_footer.html
+++ b/src/partials/90_footer.html
@@ -2,7 +2,7 @@
   <div class="footer-menu">
     <div class="container">
       <div class="row">
-        <div class="col">
+        <div class="col-sm-12 col-md-6 col-lg-3 col-xl-3">
           <div class="menu-wrapper">
             <h6>Information</h6>
             <ul>
@@ -13,7 +13,7 @@
             </ul>
           </div>
         </div>
-        <div class="col">
+        <div class="col-sm-12 col-md-6 col-lg-3 col-xl-3">
           <div class="menu-wrapper">
             <h6>My account</h6>
             <ul>
@@ -24,7 +24,7 @@
             </ul>
           </div>
         </div>
-        <div class="col">
+        <div class="col-sm-12 col-md-6 col-lg-3 col-xl-3">
           <div class="menu-wrapper">
             <h6>Information</h6>
             <ul>
@@ -35,7 +35,7 @@
             </ul>
           </div>
         </div>
-        <div class="col">
+        <div class="col-sm-12 col-md-6 col-lg-3 col-xl-3 footer-text-rwd">
           <div class="menu-wrapper">
             <h6>Orders</h6>
             <ul>
@@ -44,8 +44,9 @@
               <li><a href="#">Returns</a></li>
               <li><a href="#">Shipping</a></li>
             </ul>
+            <img src="./images/cards.png" />
           </div>
-          <img src="./images/cards.png" />
+          <div class="img-sm-center"></div>
         </div>
       </div>
     </div>
@@ -53,11 +54,11 @@
   <div class="bottom-bar">
     <div class="container">
       <div class="row align-items-center">
-        <div class="col"></div>
-        <div class="col copyright text-center">
+        <div class="col-sm-12 col-md-12 col-lg-3 col-xl-3 text-center"></div>
+        <div class="col-sm-12 col-md-6 col-lg-3 col-xl-3 copyright text-center">
           <p>©Copyright 2016 Bazar | All Rights Reserved</p>
         </div>
-        <div class="col socialmedia text-right">
+        <div class="col-sm-12 col-md-6 col-lg-3 col-xl-3 socialmedia text-right">
           <ul>
             <li>
               <a href="#"><i class="fab fa-twitter"></i></a>

--- a/src/partials/90_footer.html
+++ b/src/partials/90_footer.html
@@ -46,7 +46,6 @@
             </ul>
             <img src="./images/cards.png" />
           </div>
-          <div class="img-sm-center"></div>
         </div>
       </div>
     </div>
@@ -55,7 +54,7 @@
     <div class="container">
       <div class="row align-items-center">
         <div class="col-sm-12 col-md-12 col-lg-3 col-xl-3 text-center"></div>
-        <div class="col-sm-12 col-md-6 col-lg-3 col-xl-3 copyright text-center">
+        <div class="col-sm-12 col-md-6 col-lg-3 col-xl-3 copyright ">
           <p>©Copyright 2016 Bazar | All Rights Reserved</p>
         </div>
         <div class="col-sm-12 col-md-6 col-lg-3 col-xl-3 socialmedia text-right">

--- a/src/sass/components/_footer.scss
+++ b/src/sass/components/_footer.scss
@@ -4,6 +4,9 @@ footer {
     padding: 3rem 0;
 
     .menu-wrapper {
+      @media (max-width: 720px) {
+        text-align: center;
+      }
       h6 {
         color: #ffffff;
         text-transform: uppercase;
@@ -27,7 +30,6 @@ footer {
         }
       }
     }
-
     .payment-methods {
       margin: 0;
       padding: 0;
@@ -47,6 +49,9 @@ footer {
     }
 
     .copyright {
+      @media (max-width: 720px) {
+        text-align: left;
+      }
       p {
         margin: 0;
         color: rgb(169, 169, 169);

--- a/src/sass/components/_footer.scss
+++ b/src/sass/components/_footer.scss
@@ -49,6 +49,8 @@ footer {
     }
 
     .copyright {
+      text-align: center;
+
       @media (max-width: 720px) {
         text-align: left;
       }

--- a/src/sass/components/_product-box.scss
+++ b/src/sass/components/_product-box.scss
@@ -79,4 +79,11 @@
     justify-content: space-between;
     align-items: center;
   }
+  .old-price {
+    color: rgba(165, 165, 165);
+    font-size: 14px;
+    text-align: right;
+    text-decoration: line-through black;
+    width: 65px;
+  }
 }


### PR DESCRIPTION
Opis problemu:
Strona sypie się w trybach responsive. Klient nie ma designów RWD, więc trzeba zrobić na własną rękę. 

Ten task dotyczy stopki (linki na szarym tle, i pod nim ciemniejszy pasek na końcu strony). 

Górna partia stopki (szare tło, linki ikony metod płatności) na tabletach się mieści, ale na mniejszych ekranach chce żeby były po dwie sekcje na szerokość, a jak w najmniejszych rozdzielczościach nie będą się mieścić, to nawet 1 na szerokość (tylko w tych najmniejszych). 

W tym dolnym pasku Klient chce żeby na tablecie copyright był do lewej, a socjalki do prawej. Tam jest obecnie specjalnie zostawione miejsce po lewej, w którym na razie niczego nie ma, ale Klient prosił o uwzględnienie że może być coś dodane i wtedy na tabletach to coś ma być wyśrodkowane i na całą szerokość (nad copyright i socjalkami). 

Opis rozwiązania:
Kolumny oparłem na bootstrapowym gridzie, dodałem media queries w klasie menu-wrapper z max-width: 720 i wycentrowaniem tekstu aby na telefonach wyglądało to bardziej estetycznie (oczywiście można to zmienić w zależności od preferencji Klienta).

W klasie copyright dodałem media queries z max-width 720 text-align: left aby spełnić wymagania Klienta na tabletach i telefonach, 

Dodatkowo dodałem col-md-12 aby na tabletach jak Klient coś doda miał pełną szerokość plus text-center aby mieć treść wyśrodkowaną, 