### PR TITLE
WDP190504-37

### DIFF
--- a/src/sass/components/_product-box.scss
+++ b/src/sass/components/_product-box.scss
@@ -109,12 +109,11 @@
 
 //Tabs connected to js code
 .items_active {
-  visibility: hidden;
-  height: 330px;
+  display: none;
 }
 
 .show {
-  visibility: visible;
+  display: inline-flex;
   animation: fadein 2s;
 }
 


### PR DESCRIPTION
Wymagania:
Fix bug in furniture_section
Rozwiazanie:
Naprawione, sekcje blog i furniture nie nakladaja sie na siebie przy rozdzielczosciach mobile, tab